### PR TITLE
Jpa entity lifecycle event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,13 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/src/main/java/com/learning/entity/User.java
+++ b/src/main/java/com/learning/entity/User.java
@@ -92,9 +92,9 @@ public class User {
         log.info("Updated user: " + userName);
     }
 
-    //TODO : only annotation with failing test see : testPreLoadAnnotation() in UserRepositoryIntegrationTest.java
     @PostLoad
     public void logUserLoad() {
-        fullName = firstName + " " + lastName;
+        setFullName(firstName + " " + lastName);
+        log.info("PostLoad triggered, fullName set to: " + fullName);
     }
 }

--- a/src/main/java/com/learning/entity/User.java
+++ b/src/main/java/com/learning/entity/User.java
@@ -1,9 +1,11 @@
 package com.learning.entity;
 
+import com.learning.utils.AuditTrailListener;
 import jakarta.persistence.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+@EntityListeners(AuditTrailListener.class)
 @Entity
 public class User {
     private static Log log = LogFactory.getLog(User.class);

--- a/src/main/java/com/learning/entity/User.java
+++ b/src/main/java/com/learning/entity/User.java
@@ -1,0 +1,63 @@
+package com.learning.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Transient;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+@Entity
+public class User {
+    private static Log log = LogFactory.getLog(User.class);
+
+    @Id
+    @GeneratedValue
+    private int id;
+
+    private String userName;
+    private String firstName;
+    private String lastName;
+    @Transient
+    private String fullName;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+}

--- a/src/main/java/com/learning/entity/User.java
+++ b/src/main/java/com/learning/entity/User.java
@@ -1,9 +1,6 @@
 package com.learning.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Transient;
+import jakarta.persistence.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -59,5 +56,40 @@ public class User {
 
     public void setFullName(String fullName) {
         this.fullName = fullName;
+    }
+
+    @PrePersist
+    public void logNewUserAttempt() {
+        log.info("Attempting to add new user with username: " + userName);
+    }
+
+    @PostPersist
+    public void logNewUserAdded() {
+        log.info("Added user '" + userName + "' with ID: " + id);
+    }
+
+    @PreRemove
+    public void logUserRemovalAttempt() {
+        log.info("Attempting to delete user: " + userName);
+    }
+
+    @PostRemove
+    public void logUserRemoval() {
+        log.info("Deleted user: " + userName);
+    }
+
+    @PreUpdate
+    public void logUserUpdateAttempt() {
+        log.info("Attempting to update user: " + userName);
+    }
+
+    @PostUpdate
+    public void logUserUpdate() {
+        log.info("Updated user: " + userName);
+    }
+
+    @PostLoad
+    public void logUserLoad() {
+        fullName = firstName + " " + lastName;
     }
 }

--- a/src/main/java/com/learning/entity/User.java
+++ b/src/main/java/com/learning/entity/User.java
@@ -13,7 +13,9 @@ public class User {
     private int id;
 
     private String userName;
+    @Column(name = "first_name")
     private String firstName;
+    @Column(name = "last_name")
     private String lastName;
     @Transient
     private String fullName;
@@ -88,6 +90,7 @@ public class User {
         log.info("Updated user: " + userName);
     }
 
+    //TODO : only annotation with failing test see : testPreLoadAnnotation() in UserRepositoryIntegrationTest.java
     @PostLoad
     public void logUserLoad() {
         fullName = firstName + " " + lastName;

--- a/src/main/java/com/learning/repository/UserRepository.java
+++ b/src/main/java/com/learning/repository/UserRepository.java
@@ -2,7 +2,9 @@ package com.learning.repository;
 
 import com.learning.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Integer> {
     User findByUserName(String userName);
 }

--- a/src/main/java/com/learning/repository/UserRepository.java
+++ b/src/main/java/com/learning/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.learning.repository;
+
+import com.learning.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+    User findByUserName(String userName);
+}

--- a/src/main/java/com/learning/utils/AuditTrailListener.java
+++ b/src/main/java/com/learning/utils/AuditTrailListener.java
@@ -1,0 +1,33 @@
+package com.learning.utils;
+
+import com.learning.entity.User;
+import jakarta.persistence.*;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class AuditTrailListener {
+    private static Log log = LogFactory.getLog(AuditTrailListener.class);
+
+    @PrePersist
+    @PreUpdate
+    @PreRemove
+    private void beforeAnyUpdate(User user) {
+        if (user.getId() == 0) {
+            log.info("[USER AUDIT] About to add a user");
+        } else {
+            log.info("[USER AUDIT] About to update/delete user: " + user.getId());
+        }
+    }
+
+    @PostPersist
+    @PostUpdate
+    @PostRemove
+    private void afterAnyUpdate(User user) {
+        log.info("[USER AUDIT] add/update/delete complete for user: " + user.getId());
+    }
+
+    @PostLoad
+    private void afterLoad(User user) {
+        log.info("[USER AUDIT] user loaded from database: " + user.getId());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,4 +11,5 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        default_schema: SCHOOL
+        default_schema: public
+        dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/test/java/com/learning/HibernateDemoApplicationTests.java
+++ b/src/test/java/com/learning/HibernateDemoApplicationTests.java
@@ -1,0 +1,11 @@
+package com.learning;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class HibernateDemoApplicationTests {
+    @Test
+    void contextLoads() {
+    }
+}

--- a/src/test/java/com/learning/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/com/learning/repository/UserRepositoryIntegrationTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 
 import java.util.Optional;
@@ -71,14 +73,14 @@ public class UserRepositoryIntegrationTest {
     }
 
     @Test
-    @Disabled
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void testPreLoadAnnotation(){
         User bob = userRepository.findByUserName("Boby");
         assertEquals("Bob User", bob.getFullName());
     }
 
     @Test
-    @Disabled
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void testPreLoadAnnotation_2(){
         User bob = userRepository.findByUserName("Boby");
         Integer bobId = bob.getId();

--- a/src/test/java/com/learning/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/com/learning/repository/UserRepositoryIntegrationTest.java
@@ -85,7 +85,7 @@ public class UserRepositoryIntegrationTest {
         User bob = userRepository.findByUserName("Boby");
         Integer bobId = bob.getId();
 
-        Optional<User> foundUser = userRepository.findById(bobId); //Find by id but still not work !
+        Optional<User> foundUser = userRepository.findById(bobId);
         assertTrue(foundUser.isPresent());
         assertEquals("Bob User", foundUser.get().getFullName());
     }

--- a/src/test/java/com/learning/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/com/learning/repository/UserRepositoryIntegrationTest.java
@@ -1,0 +1,54 @@
+package com.learning.repository;
+
+import com.learning.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class UserRepositoryIntegrationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    public void setup() {
+        userRepository.deleteAll();
+
+        User bob = new User();
+        bob.setUserName("Boby");
+        bob.setFirstName("Bob");
+        bob.setLastName("User");
+        userRepository.save(bob);
+
+        User alice = new User();
+        alice.setUserName("Aliiice");
+        alice.setFirstName("Alice");
+        alice.setLastName("User");
+        userRepository.save(alice);
+    }
+
+
+    @Test
+    public void testFindByUserName_UserExists() {
+        User foundUser = userRepository.findByUserName("Boby");
+
+        assertEquals("Boby", foundUser.getUserName());
+        assertEquals("Bob", foundUser.getFirstName());
+        assertEquals("User", foundUser.getLastName());
+    }
+
+    @Test
+    public void testFindByUserName_UserDoesNotExist() {
+        User foundUser = userRepository.findByUserName("nonExistingUser");
+
+        assertNull(foundUser);
+    }
+}

--- a/src/test/java/com/learning/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/com/learning/repository/UserRepositoryIntegrationTest.java
@@ -1,15 +1,13 @@
 package com.learning.repository;
 
 import com.learning.entity.User;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -35,7 +33,6 @@ public class UserRepositoryIntegrationTest {
         userRepository.save(alice);
     }
 
-
     @Test
     public void testFindByUserName_UserExists() {
         User foundUser = userRepository.findByUserName("Boby");
@@ -50,5 +47,31 @@ public class UserRepositoryIntegrationTest {
         User foundUser = userRepository.findByUserName("nonExistingUser");
 
         assertNull(foundUser);
+    }
+
+    @Test
+    public void testUpdateUser() {
+        User bob = userRepository.findByUserName("Boby");
+        bob.setFirstName("Bobby");
+        userRepository.save(bob);
+
+        User foundUser = userRepository.findByUserName("Boby");
+        assertEquals("Bobby", foundUser.getFirstName());
+    }
+
+    @Test
+    public void testDeleteUser() {
+        User bob = userRepository.findByUserName("Boby");
+        userRepository.delete(bob);
+
+        User foundUser = userRepository.findByUserName("Boby");
+        assertNull(foundUser);
+    }
+
+    @Test
+    @Disabled
+    public void testPreLoadAnnotation(){
+        User bob = userRepository.findByUserName("Boby");
+        assertEquals("Bob User", bob.getFullName());
     }
 }

--- a/src/test/java/com/learning/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/com/learning/repository/UserRepositoryIntegrationTest.java
@@ -7,6 +7,8 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
@@ -73,5 +75,16 @@ public class UserRepositoryIntegrationTest {
     public void testPreLoadAnnotation(){
         User bob = userRepository.findByUserName("Boby");
         assertEquals("Bob User", bob.getFullName());
+    }
+
+    @Test
+    @Disabled
+    public void testPreLoadAnnotation_2(){
+        User bob = userRepository.findByUserName("Boby");
+        Integer bobId = bob.getId();
+
+        Optional<User> foundUser = userRepository.findById(bobId); //Find by id but still not work !
+        assertTrue(foundUser.isPresent());
+        assertEquals("Bob User", foundUser.get().getFullName());
     }
 }


### PR DESCRIPTION
When working with JPA, there are several events that we can be notified of during an entity’s lifecycle. In this tutorial, we’ll discuss the JPA entity lifecycle events and how we can use annotations to handle the callbacks and execute code when these events occur.

We’ll start by annotating methods on the entity itself and then move on to using an entity listener.

JPA specifies seven optional lifecycle events that are called:

    before persist is called for a new entity – @PrePersist
    after persist is called for a new entity – @PostPersist
    before an entity is removed – @PreRemove
    after an entity has been deleted – @PostRemove
    before the update operation – @PreUpdate
    after an entity is updated – @PostUpdate
    after an entity has been loaded – @PostLoad

There are two approaches for using the lifecycle event annotations: annotating methods in the entity and creating an EntityListener with annotated callback methods. We can also use both at the same time. Regardless of where they are, callback methods are required to have a void return type.

So, if we create a new entity and call the save method of our repository, our method annotated with @PrePersist is called, then the record is inserted into the database, and finally, our @PostPersist method is called. If we’re using @GeneratedValue to automatically generate our primary keys, we can expect that key to be available in the @PostPersist method.

For the @PostPersist, @PostRemove and @PostUpdate operations, the documentation mentions that these events can happen right after the operation occurs, after a flush, or at the end of a transaction.

We should note that the @PreUpdate callback is only called if the data is actually changed — that is if there’s an actual SQL update statement to run. The @PostUpdate callback is called regardless of whether anything actually changed.

If any of our callbacks for persisting or removing an entity throw an exception, the transaction will be rolled back.